### PR TITLE
fix postgres port in step 5

### DIFF
--- a/detail_guides/5-setup_nextcloud.md
+++ b/detail_guides/5-setup_nextcloud.md
@@ -64,7 +64,7 @@ git clone https://github.com/hackerbande-nbg/decentralize-your-internet.git
   - Database Account: postgres
   - Database Password: Enter the one you chose in [Step 7](#step-7---run-nextcloud) as POSTGRES_PW
   - Database Name: postgres
-  - Database Host: <postgres container name from [Step 7](#step-7---run-nextcloud)>:5433
+  - Database Host: <postgres container name from [Step 7](#step-7---run-nextcloud)>:5432
 - Click on "Install"
   - Button should switch to "Installing" - patience!
 - On the next page click "Install recommended Apps" or make a choice 


### PR DESCRIPTION
in step 5 when configuring nextcloud, I believe the port for postgres should be 5432 instead of 5433. because nextcloud and postgres are on the same docker network, nextcloud can talk to postgres on port 5432 directly.

I don't know if it is also supposed to work with port 5433, but it seems like for at least some people it did not work: #24 